### PR TITLE
Fixed incorrect dwMaxFileCount value for SFileCreateArchive

### DIFF
--- a/src/StormLibSharp/MpqArchive.cs
+++ b/src/StormLibSharp/MpqArchive.cs
@@ -72,7 +72,7 @@ namespace StormLibSharp
 
             //if (!NativeMethods.SFileCreateArchive2(filePath, ref create, out _handle))
             //    throw new Win32Exception();
-            if (!NativeMethods.SFileCreateArchive(filePath, (uint)flags, int.MaxValue, out _handle))
+            if (!NativeMethods.SFileCreateArchive(filePath, (uint)flags, (uint)maxFileCount, out _handle))
                 throw new Win32Exception();
         }
 


### PR DESCRIPTION
So, took alittle awhile to find out why MPQs had an additional 8mb of
garbage data at the end of them compared to Ladik's editor. I thought
maybe there was a more siginificant fault related to writing the MPQ. In
was just a result of SFileCreateArchive in Stormsharplib always passing
int.MaxValue even if you provided your own count.

This fix address this.

Special thanks to Sundays for walking me through some of the MPQ format stuff to help narrow down the scope of what could be causing this massive chunk of garbage data.